### PR TITLE
Add public repo notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ## StackGuardian CLI (sg-cli)
 
+> **Note:** This repository hosts release binaries only. The source code is
+> maintained in a private repository. Issues, pull requests, and discussions
+> are not monitored here — please reach out via [support@stackguardian.io](mailto:support@stackguardian.io)
+> or your usual support channel.
+
 ### 1: Setup
 
 Required environment variables:


### PR DESCRIPTION
## Summary

- Add note to README clarifying this repo hosts release binaries only
- Source code is maintained in a private repository
- Directs users to support@stackguardian.io for issues and discussions
